### PR TITLE
Fix odd issue with img proxy

### DIFF
--- a/fullerene/__init__.py
+++ b/fullerene/__init__.py
@@ -185,4 +185,4 @@ def host(domain, host, metric_group, period):
 def render():
     uri = config.graphite.uri + "/render/"
     response = requests.get(uri, params=flask.request.args)
-    return flask.Response(response=response.raw, headers=response.headers)
+    return flask.Response(response=response.raw.read(), headers=response.headers)


### PR DESCRIPTION
The original code did not function as it should. It threw an exception as the raw response object was not iterable.

Reading it directly out fixes the issue.

I am not really sure what is happening here, so this may not be required upstream.
